### PR TITLE
:bug: correct eventemitter3 url

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -129,7 +129,7 @@
 <script defer src="https://use.fontawesome.com/releases/v5.0.2/js/all.js"></script>
 
 <script src="https://webrtc.github.io/adapter/adapter-6.0.3.js"></script>
-<script src="https://unpkg.com/eventemitter3@latest/umd/eventemitter3.min.js"></script>
+<script src="https://unpkg.com/eventemitter3@latest/dist/eventemitter3.umd.min.js"></script>
 
 <script src="/js/class/turntest.js"></script>
 <script src="/js/class/resultview.js"></script>


### PR DESCRIPTION
Currently the site https://icetest.info/ is broken with `EventEmitter3 is not defined` this is because a new release has been made https://github.com/primus/eventemitter3/releases/tag/5.0.0 and the `umd` directory no longer exist.

This PR use the correct path. Note that I left the `@latest` so this may break later (but I think this is better for security fixes)