### PR TITLE
:lipstick: Change column width for compact view

### DIFF
--- a/web/js/class/resultview.js
+++ b/web/js/class/resultview.js
@@ -18,10 +18,10 @@ class ResultView {
 
     this.turnTest.on('icecandidate', (candidate) => {
       let template = `<div class="col-12"><div class="row">
-        <div class="col-2">${candidate.type}</div>
-        <div class="col-2">${candidate.protocol}</div>
-        <div class="col-4">${candidate.ip}:${candidate.port}</div>
-        <div class="col-4">${ candidate.relatedAddress ? candidate.relatedAddress +':' + candidate.relatedPort : 'N/A'}</div>
+        <div class="col-1">${candidate.type}</div>
+        <div class="col-1">${candidate.protocol}</div>
+        <div class="col-5 px-3">${candidate.address}:${candidate.port}</div>
+        <div class="col-5 px-3">${candidate.relatedAddress ? candidate.relatedAddress + ':' + candidate.relatedPort : 'N/A'}</div>
       </div></div>`
 
       let e = document.createElement('div')


### PR DESCRIPTION
Update column width so IPv6 addresses can be displayed on a single line on medium screen (<=1200px)

Update non standard `ip` field to standard `address` field (https://w3c.github.io/webrtc-pc/#rtcicecandidate-interface)

Note: I did not test the change for `ip` to `address`, but MDN documentation does redirect https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/ip to https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/address and the specification does not mention an `ip` field