### PR TITLE
:bug: fallback to `ip`, remove padding completely

### DIFF
--- a/web/js/class/resultview.js
+++ b/web/js/class/resultview.js
@@ -20,7 +20,7 @@ class ResultView {
       let template = `<div class="col-12"><div class="row">
         <div class="col-1">${candidate.type}</div>
         <div class="col-1">${candidate.protocol}</div>
-        <div class="col-5 px-3">${candidate.address}:${candidate.port}</div>
+        <div class="col-5 px-3">${candidate.ip}:${candidate.port}</div>
         <div class="col-5 px-3">${candidate.relatedAddress ? candidate.relatedAddress + ':' + candidate.relatedPort : 'N/A'}</div>
       </div></div>`
 

--- a/web/js/class/resultview.js
+++ b/web/js/class/resultview.js
@@ -20,8 +20,8 @@ class ResultView {
       let template = `<div class="col-12"><div class="row">
         <div class="col-1">${candidate.type}</div>
         <div class="col-1">${candidate.protocol}</div>
-        <div class="col-5 px-3">${candidate.ip}:${candidate.port}</div>
-        <div class="col-5 px-3">${candidate.relatedAddress ? candidate.relatedAddress + ':' + candidate.relatedPort : 'N/A'}</div>
+        <div class="col-5 px-0">${candidate.address || candidate.ip}:${candidate.port}</div>
+        <div class="col-5 px-0">${candidate.relatedAddress ? candidate.relatedAddress + ':' + candidate.relatedPort : 'N/A'}</div>
       </div></div>`
 
       let e = document.createElement('div')


### PR DESCRIPTION
Firefox108 still does not have `address` field,
Chrome 108 have the `address` field.

With certain font, the padding was too big.